### PR TITLE
Change '2018 Retrospective' title to be 100%

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -85,6 +85,7 @@ nav {
     }
     img {
       width: auto;
+      max-width: 100%;
       height: auto;
     }
   }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -403,7 +403,7 @@ header, .hero {
       font-weight: 900;
     }
     .line-1 { font-size: 38px; float: left; clear: right; margin-left: 20px; margin-top: 18px; font-weight: normal; width: 60%; }
-    .line-2 { font-size: 58px; float: left; clear: right; margin-left: 20px; line-height: 66px; width: 60%; font-weight: bold; }
+    .line-2 { font-size: 58px; float: left; clear: right; margin-left: 20px; line-height: 66px; width: 100%; font-weight: bold; }
     .line-3 { font-size: 20px; float: left; clear: both;  font-family: 'Roboto'; width: 50%; line-height: 24px; font-weight: normal; }
 
     ~ p {


### PR DESCRIPTION
(Not sure if it was intentional to have the title be 60% width and the image be 100% - in case it is, reject this pull request!)